### PR TITLE
fix(harness): DSH_PORT in .env is fatal to current dsh; rename + spawn from .dsh

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,11 +97,11 @@ HOST=0.0.0.0
 #   server  - start it, open nothing (you open the URL yourself)
 #   no      - do not start it at all; /v1 still serves every other client
 UI=browser
-# The port the harness listens on. A harness left over from a run that was
-# closed rather than stopped still holds it; the launcher says so and leaves
-# both alone rather than starting a second one that cannot bind. windows\stop.bat
-# clears the leftover, or move this out of its way.
-DSH_PORT=3080
+# The port the harness listens on. Do not name this DSH_PORT: current dsh
+# treats DSH_PORT in a .env file as fatal ("export it instead") and the chat
+# UI never binds, even though /v1 is already up. A leftover harness still
+# holding the port is cleared by windows\stop.bat / ./linux/stop.sh.
+SIMPLEX_HARNESS_PORT=3080
 # The npm version to run. dsh is in developer preview and breaks compatibility
 # between releases, so this is pinned; `latest` follows the newest instead.
 # A version npm does not have falls back to `latest` with a line saying so.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ at setup, and you can change it any time.
 | GPU | NVIDIA, 12 GB VRAM or more, compute capability 7.5+ (Turing and newer). 16 GB is the size this kit was built around. |
 | Driver | 570 or newer (the default PyTorch build is cu128). |
 | Python | **3.11 or newer, 64-bit.** The only thing you install by hand. |
-| Node | LTS from [nodejs.org](https://nodejs.org/) — needed for the chat UI. Without it `/v1` still serves; the launcher says what is missing. |
+| Node | **22.19+** from [nodejs.org](https://nodejs.org/) (current dsh). Older LTS (20) warns `EBADENGINE` and the chat UI may fail. Without Node, `/v1` still serves; the launcher says what is missing. |
 | Disk | 9.7–22.9 GB per quant (see the table below), plus several GB for the Python environment and PyTorch. |
 
 **Not needed:** CUDA Toolkit, Visual Studio Build Tools, Git. The engine arrives as a
@@ -402,10 +402,10 @@ token is a session on an agent that runs commands here.
 
 | | |
 | --- | --- |
-| Harness | `http://127.0.0.1:3080/` (`DSH_PORT` in `.env`) |
+| Harness | `http://127.0.0.1:3080/` (`SIMPLEX_HARNESS_PORT` in `.env`; do not use `DSH_PORT` there) |
 | Version | `DSH_VERSION` in `.env`, pinned; `latest` follows the newest |
 | Its home | `.dsh/` in the kit folder — settings, credentials, profiles, plugins |
-| Run it alone | `tools/dsh.py --open`, with the kit's venv Python and the server already up |
+| Run it alone | From the **kit root** (not `C:\Windows\System32`): `python tools/dsh.py --open`. PowerShell: `Set-Location -LiteralPath <kit>`; cmd: `cd /d <kit>`. `cd /d` is not valid in PowerShell. |
 | Just the settings | `tools/dsh.py --settings-only` |
 
 The harness binds loopback only and **refuses to bind `0.0.0.0` at all**: its agent
@@ -609,7 +609,7 @@ fine. The ones you are most likely to touch:
 | `PORT` | `8888` | the OpenAI API port |
 | `HOST` | `0.0.0.0` | set to `127.0.0.1` to keep `/v1` off your network |
 | `UI` | `browser` | `browser`, `server`, or `no` |
-| `DSH_PORT` | `3080` | the chat UI's port |
+| `SIMPLEX_HARNESS_PORT` | `3080` | the chat UI's port. Do **not** set `DSH_PORT` in `.env` — current dsh treats that key in a file as fatal and the harness never binds |
 | `DRAFT` | `mtp` | `none` turns off speculative decoding |
 | `SETUP` | `browser` | `console` for terminal questions on Windows |
 | `TRAY` | `auto` | Windows notification-area icon; `no` to skip |

--- a/linux/start.sh
+++ b/linux/start.sh
@@ -497,7 +497,7 @@ fi
 UI="${UI:-browser}"
 # --harness / --no-harness, and `simplex start --no-harness`, which sets this.
 UI="${SIMPLEX_UI:-$UI}"
-DSH_PORT="${DSH_PORT:-3080}"
+DSH_PORT="${SIMPLEX_HARNESS_PORT:-${DSH_PORT:-3080}}"
 case "$UI" in
     1|yes|true|on|browser) UI=browser ;;
     0|no|none|off|false)   UI=no ;;

--- a/tools/cli.py
+++ b/tools/cli.py
@@ -53,6 +53,8 @@ WINDOWS = os.name == "nt"
 if str(TOOLS) not in sys.path:
     sys.path.insert(0, str(TOOLS))
 
+import dsh
+
 
 # --------------------------------------------------------------- colour ----
 def _colour_ok() -> bool:
@@ -317,7 +319,7 @@ def snapshot() -> dict:
     """Everything `status` reports, in one dict - also what --json prints."""
     cfg = read_env()
     port = env_int(cfg, "PORT", 8888)
-    dsh_port = env_int(cfg, "DSH_PORT", 3080)
+    dsh_port = dsh.port_from_cfg(cfg)
     state = {
         "root": str(ROOT),
         "server": {"port": port, "running": False, "pid": 0, "model": None,
@@ -475,7 +477,7 @@ def cmd_start(a) -> int:
 def cmd_stop(a) -> int:
     cfg = read_env()
     port = a.port or env_int(cfg, "PORT", 8888)
-    dsh_port = env_int(cfg, "DSH_PORT", 3080)
+    dsh_port = dsh.port_from_cfg(cfg)
     rc = 0
 
     if not a.server_only:
@@ -611,7 +613,7 @@ def cmd_logs(a) -> int:
 def cmd_harness(a) -> int:
     import dsh                                              # noqa: WPS433
     cfg = read_env()
-    port = env_int(cfg, "DSH_PORT", dsh.DEFAULT_PORT)
+    port = a.port or dsh.port_from_cfg(cfg)
     base = f"http://127.0.0.1:{env_int(cfg, 'PORT', 8888)}/v1"
 
     if a.action == "status":
@@ -816,7 +818,7 @@ def cmd_doctor(a) -> int:
         warn("node", "not installed - the harness cannot run (UI=no skips it)")
 
     port = env_int(cfg, "PORT", 8888)
-    dsh_port = env_int(cfg, "DSH_PORT", 3080)
+    dsh_port = dsh.port_from_cfg(cfg)
     for label, p in (("model port", port), ("harness port", dsh_port)):
         if port_listening(p):
             pid, cmdl = port_owner(p)

--- a/tools/dsh.py
+++ b/tools/dsh.py
@@ -58,6 +58,13 @@ from pathlib import Path
 # preview and moving fast - and the wrong one when a run has to reproduce.
 DEFAULT_VERSION = "0.1.3-alpha.2"
 DEFAULT_PORT = 3080
+
+
+def port_from_cfg(cfg: dict, default: int = DEFAULT_PORT) -> int:
+    """Harness bind port. Prefer SIMPLEX_HARNESS_PORT; DSH_PORT in a .env
+    file is fatal to current dsh-app-boot, so new kits do not ship it."""
+    raw = cfg.get("SIMPLEX_HARNESS_PORT") or cfg.get("DSH_PORT") or default
+    return int(raw)
 PACKAGE = "@deepseek-ai/dsh"
 
 # The provider route dsh serves this kit's model on. The id is permanent as far
@@ -501,8 +508,14 @@ def start(root: Path, port: int = DEFAULT_PORT, version: str = DEFAULT_VERSION,
     if extra_env:
         env.update(extra_env)
     home(root).mkdir(parents=True, exist_ok=True)
+    # Current dsh (dsh-app-boot) walks parent dirs for a .env and *refuses*
+    # reserved keys such as DSH_PORT in that file ("export it instead").
+    # Our kit .env used to ship DSH_PORT=3080, which killed the harness after
+    # /v1 was already up. cwd is .dsh (DSH_HOME) so that walk does not see
+    # the kit .env; the port is already on the CLI as `dsh web --port`.
+    env.setdefault("DSH_PORT", str(port))
     return subprocess.Popen(
-        command(version, port), cwd=str(root), env=env,
+        command(version, port), cwd=str(home(root)), env=env,
         stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=0,
         shell=False)
 
@@ -605,7 +618,8 @@ def main() -> int:
                 k, _, v = line.partition("=")
                 cfg[k.strip()] = v.split("#")[0].strip().strip('"').strip("'")
 
-    port = args.port or int(cfg.get("DSH_PORT") or DEFAULT_PORT)
+    port = args.port or int(
+        cfg.get("SIMPLEX_HARNESS_PORT") or cfg.get("DSH_PORT") or DEFAULT_PORT)
     version = args.version or cfg.get("DSH_VERSION") or DEFAULT_VERSION
     base = args.base or f"http://127.0.0.1:{cfg.get('PORT', '8888')}/v1"
 

--- a/tools/win_start.py
+++ b/tools/win_start.py
@@ -1069,7 +1069,7 @@ def harness_after_ready(proc: subprocess.Popen, host: str, port: str,
         info(f"The API is serving at {cyan(base)} in the meantime.")
         return
 
-    hport = int(cfg.get("DSH_PORT") or dsh.DEFAULT_PORT)
+    hport = dsh.port_from_cfg(cfg)
     version = (cfg.get("DSH_VERSION") or dsh.DEFAULT_VERSION).strip()
 
     # A harness from a run that did not shut down cleanly still holds the port.
@@ -1093,7 +1093,7 @@ def harness_after_ready(proc: subprocess.Popen, host: str, port: str,
         warn(f"port {hport} is held by something this kit cannot get into - "
              f"a harness left over from a run that did not shut down, or "
              f"another program")
-        info("windows\\stop.bat clears a leftover harness; DSH_PORT in .env moves this "
+        info("windows\\stop.bat clears a leftover harness; SIMPLEX_HARNESS_PORT in .env moves this "
              "one out of the way.")
         info(f"The API is serving at {cyan(base)} in the meantime.")
         return
@@ -1344,7 +1344,7 @@ def server_command(cfg: dict[str, str]):
     cmd.extend(["--vision", vision_mode, "--image_max_pixels", image_max_pixels])
     ui = ui_mode(cfg)
     cmd.extend(["--ui", "off" if ui == "no" else "on"])
-    cmd.extend(["--harness_port", str(cfg.get("DSH_PORT") or "3080")])
+    cmd.extend(["--harness_port", str(cfg.get("SIMPLEX_HARNESS_PORT") or cfg.get("DSH_PORT") or "3080")])
     return cmd, host, port, gpu_mem, ui, context
 
 
@@ -1467,7 +1467,7 @@ def main() -> int:
     info("The Ready box appears after load finishes  - do not connect yet.")
     if ui != "no":
         info(f"The harness starts after that, at "
-             f"http://127.0.0.1:{cfg.get('DSH_PORT') or '3080'}/.")
+             f"http://127.0.0.1:{cfg.get('SIMPLEX_HARNESS_PORT') or cfg.get('DSH_PORT') or '3080'}/.")
     if prep is not None:
         info("After Ready you will be asked whether to open Cherry Studio.")
     print()


### PR DESCRIPTION
## Summary

Fresh Windows zip install: the model loaded and `/v1` served (`qwen3.8-27b-exl3-3.0bpw`), but the DeepSeek Harness never came up on `:3080`.

Current `dsh-app-boot` walks parent `.env` files and **refuses reserved keys**:

```
.env sets "DSH_PORT", which only the launching environment may set
  (export DSH_PORT instead of putting it in a .env file)
```

This kit shipped `DSH_PORT=3080` in `.env.example`, so a first-run user gets a working API and a dead chat UI.

## Changes

- `.env.example`: `SIMPLEX_HARNESS_PORT=3080` (do not name it `DSH_PORT`)
- `tools/dsh.py`: spawn `dsh web` with `cwd=.dsh` and `DSH_PORT` only in the **child environment**; still read a leftover `DSH_PORT` from existing `.env` files
- README: Node **22.19+** (dsh floor; Node 20 is `EBADENGINE`); `tools/dsh.py --open` must be run from the **kit root**. PowerShell is `Set-Location -LiteralPath …`; `cd /d` is cmd-only and leaves python in `C:\Windows\System32`

## Test plan

- [ ] New `.env` from `.env.example` has no `DSH_PORT` line
- [ ] After `/v1` is Ready, harness binds `:3080` without the dsh-app-boot error
- [ ] Existing `.env` that still has `DSH_PORT=` still starts (cwd=.dsh so dsh does not load the kit file)
- [ ] PowerShell snippet in README does not use `cd /d`